### PR TITLE
More settings

### DIFF
--- a/Network/HTTP2/TLS/Client/Settings.hs
+++ b/Network/HTTP2/TLS/Client/Settings.hs
@@ -1,0 +1,39 @@
+module Network.HTTP2.TLS.Client.Settings where
+
+import Data.X509.CertificateStore (CertificateStore)
+import Network.Socket
+
+-- Client settings type.
+data Settings = Settings
+    { settingsKeyLogger :: String -> IO ()
+    -- ^ Key logger (defaults to none)
+    --
+    -- Applications may wish to set this depending on the SSLKEYLOGFILE environment variable.
+
+    , settingsValidateCert :: Bool
+    -- ^ Should we validate TLS certificates?
+    --
+    -- Defaults to @False@
+
+    , settingsCAStore :: CertificateStore
+    -- ^ Certificate store used for validation
+    --
+    -- Defaults to @mempty@
+
+    , settingsAddrInfoFlags :: [AddrInfoFlag]
+    -- ^ Flags that control the querying behaviour of @getAddrInfo@.
+    --
+    -- Defaults to @[AI_ADDRCONFIG, AI_NUMERICHOST, AI_NUMERICSERV]@
+    }
+
+-- | Default settings.
+defaultSettings :: Settings
+defaultSettings =
+    Settings
+        { settingsKeyLogger     = \_ -> return ()
+        , settingsValidateCert  = False
+        , settingsCAStore       = mempty
+        , settingsAddrInfoFlags = [AI_ADDRCONFIG, AI_NUMERICHOST, AI_NUMERICSERV]
+        }
+
+

--- a/Network/HTTP2/TLS/Client/Settings.hs
+++ b/Network/HTTP2/TLS/Client/Settings.hs
@@ -31,7 +31,7 @@ defaultSettings :: Settings
 defaultSettings =
     Settings
         { settingsKeyLogger     = \_ -> return ()
-        , settingsValidateCert  = False
+        , settingsValidateCert  = True
         , settingsCAStore       = mempty
         , settingsAddrInfoFlags = [AI_ADDRCONFIG, AI_NUMERICHOST, AI_NUMERICSERV]
         }

--- a/Network/HTTP2/TLS/Client/Settings.hs
+++ b/Network/HTTP2/TLS/Client/Settings.hs
@@ -6,24 +6,30 @@ import Network.Socket
 -- Client settings type.
 data Settings = Settings
     { settingsKeyLogger :: String -> IO ()
-    -- ^ Key logger (defaults to none)
+    -- ^ Key logger
     --
     -- Applications may wish to set this depending on the SSLKEYLOGFILE environment variable.
+    --
+    -- >>> settingsKeyLogger defaultSettings
+    -- \_ -> return ()
 
     , settingsValidateCert :: Bool
     -- ^ Should we validate TLS certificates?
     --
-    -- Defaults to @False@
+    -- >>> settingsValidateCert defaultSettings
+    -- True
 
     , settingsCAStore :: CertificateStore
     -- ^ Certificate store used for validation
     --
-    -- Defaults to @mempty@
+    -- >>> settingsCAStore defaultSettings
+    -- mempty
 
     , settingsAddrInfoFlags :: [AddrInfoFlag]
     -- ^ Flags that control the querying behaviour of @getAddrInfo@.
     --
-    -- Defaults to @[AI_ADDRCONFIG, AI_NUMERICHOST, AI_NUMERICSERV]@
+    -- >>> settingsAddrInfoFlags defaultSettings
+    -- []
     }
 
 -- | Default settings.

--- a/Network/HTTP2/TLS/Client/Settings.hs
+++ b/Network/HTTP2/TLS/Client/Settings.hs
@@ -33,7 +33,7 @@ defaultSettings =
         { settingsKeyLogger     = \_ -> return ()
         , settingsValidateCert  = True
         , settingsCAStore       = mempty
-        , settingsAddrInfoFlags = [AI_ADDRCONFIG, AI_NUMERICHOST, AI_NUMERICSERV]
+        , settingsAddrInfoFlags = []
         }
 
 

--- a/Network/HTTP2/TLS/Config.hs
+++ b/Network/HTTP2/TLS/Config.hs
@@ -13,7 +13,7 @@ import Network.Socket (SockAddr)
 import Network.Socket.BufferPool
 import qualified System.TimeManager as T
 
-import Network.HTTP2.TLS.Settings
+import Network.HTTP2.TLS.Server.Settings
 
 allocConfigForServer
     :: Settings -> T.Manager -> (ByteString -> IO ()) -> IO ByteString -> SockAddr -> SockAddr -> IO Config

--- a/Network/HTTP2/TLS/IO.hs
+++ b/Network/HTTP2/TLS/IO.hs
@@ -27,7 +27,7 @@ import Network.HTTP2.TLS.Server.Settings
 
 mkRecvTCP :: Settings -> Socket -> IO (IO ByteString)
 mkRecvTCP Settings{..} sock = do
-    pool <- newBufferPool settingReadBufferLowerLimit settingReadBufferSize
+    pool <- newBufferPool settingsReadBufferLowerLimit settingsReadBufferSize
     return $ receive sock pool
 
 sendTCP :: Socket -> ByteString -> IO ()

--- a/Network/HTTP2/TLS/IO.hs
+++ b/Network/HTTP2/TLS/IO.hs
@@ -16,7 +16,7 @@ import System.IO.Error (isEOFError)
 import qualified System.TimeManager as T
 import qualified UnliftIO.Exception as E
 
-import Network.HTTP2.TLS.Settings
+import Network.HTTP2.TLS.Server.Settings
 
 ----------------------------------------------------------------
 

--- a/Network/HTTP2/TLS/Internal.hs
+++ b/Network/HTTP2/TLS/Internal.hs
@@ -1,5 +1,17 @@
+{-# LANGUAGE CPP #-}
+
 module Network.HTTP2.TLS.Internal (
     module Network.HTTP2.TLS.IO,
+    gclose,
 ) where
 
+import Network.Socket
+
 import Network.HTTP2.TLS.IO
+
+gclose :: Socket -> IO ()
+#if MIN_VERSION_network(3,1,1)
+gclose sock = gracefulClose sock 5000
+#else
+gclose = close
+#endif

--- a/Network/HTTP2/TLS/Server.hs
+++ b/Network/HTTP2/TLS/Server.hs
@@ -18,6 +18,7 @@ module Network.HTTP2.TLS.Server (
     settingsSlowlorisSize,
     settingReadBufferSize,
     settingReadBufferLowerLimit,
+    settingsKeyLogger,
 
     -- * IO backend
     IOBackend,
@@ -43,7 +44,7 @@ import qualified UnliftIO.Exception as E
 
 import Network.HTTP2.TLS.Config
 import Network.HTTP2.TLS.IO
-import Network.HTTP2.TLS.Settings
+import Network.HTTP2.TLS.Server.Settings
 import Network.HTTP2.TLS.Supported
 
 -- | Running a TLS client.
@@ -66,7 +67,7 @@ runTLS settings@Settings{..} creds host port alpn action =
             iobackend <- timeoutIOBackend th settings <$> tlsIOBackend ctx sock
             action mgr iobackend
   where
-    params = getServerParams creds alpn
+    params = getServerParams creds alpn settingsKeyLogger
 
 -- | Running an HTTP\/2 client over TLS (over TCP).
 --   ALPN is "h2".
@@ -94,12 +95,14 @@ run' settings server mgr IOBackend{..} =
 getServerParams
     :: Credentials
     -> ByteString
+    -> (String -> IO ())
     -> ServerParams
-getServerParams creds alpn =
+getServerParams creds alpn keyLogger =
     def
         { serverSupported = supported
         , serverShared = shared
         , serverHooks = hooks
+        , serverDebug = debug
         }
   where
     shared =
@@ -111,6 +114,10 @@ getServerParams creds alpn =
     hooks =
         def
             { onALPNClientSuggest = Just $ selectALPN alpn
+            }
+    debug =
+        def
+            { debugKeyLogger = keyLogger
             }
 
 selectALPN :: ByteString -> [ByteString] -> IO ByteString

--- a/Network/HTTP2/TLS/Server.hs
+++ b/Network/HTTP2/TLS/Server.hs
@@ -16,8 +16,8 @@ module Network.HTTP2.TLS.Server (
     settingsTimeout,
     settingsSendBufferSize,
     settingsSlowlorisSize,
-    settingReadBufferSize,
-    settingReadBufferLowerLimit,
+    settingsReadBufferSize,
+    settingsReadBufferLowerLimit,
     settingsKeyLogger,
 
     -- * IO backend

--- a/Network/HTTP2/TLS/Server/Settings.hs
+++ b/Network/HTTP2/TLS/Server/Settings.hs
@@ -1,6 +1,6 @@
-module Network.HTTP2.TLS.Settings where
+module Network.HTTP2.TLS.Server.Settings where
 
--- Settings type.
+-- Server settings type.
 data Settings = Settings
     { settingsTimeout :: Int
     -- ^ Timeout in seconds. (All)
@@ -14,12 +14,13 @@ data Settings = Settings
     -- ^ When the size of a read buffer is lower than this limit, the buffer is thrown awany (and is eventually freed). Then a new buffer is allocated. (All)
     , settingReadBufferLowerLimit :: Int
     -- ^  The allocation size for a read buffer.  (All)
-    } deriving (Eq, Show)
+    , settingsKeyLogger :: String -> IO ()
+    -- ^ Key logger (defaults to none)
+    --
+    -- Applications may wish to set this depending on the SSLKEYLOGFILE environment variable.
+    }
 
 -- | Default settings.
---
--- >>> defaultSettings
--- Settings {settingsTimeout = 30, settingsSendBufferSize = 4096, settingsSlowlorisSize = 50, settingReadBufferSize = 16384, settingReadBufferLowerLimit = 2048}
 defaultSettings :: Settings
 defaultSettings =
     Settings
@@ -28,4 +29,5 @@ defaultSettings =
         , settingsSlowlorisSize = 50
         , settingReadBufferSize = 16384
         , settingReadBufferLowerLimit = 2048
+        , settingsKeyLogger = \_ -> return ()
         }

--- a/Network/HTTP2/TLS/Server/Settings.hs
+++ b/Network/HTTP2/TLS/Server/Settings.hs
@@ -4,20 +4,43 @@ module Network.HTTP2.TLS.Server.Settings where
 data Settings = Settings
     { settingsTimeout :: Int
     -- ^ Timeout in seconds. (All)
+    --
+    -- >>> settingsTimeout defaultSettings
+    -- 30
+
     , settingsSendBufferSize :: Int
     -- ^ Send buffer size. (H2 and H2c)
+    --
+    -- >>> settingsSendBufferSize defaultSettings
+    -- 4096
+
     , settingsSlowlorisSize :: Int
     -- ^ If the size of receiving data is less than or equal,
     --   the timeout is not reset.
     --   (All)
+    --
+    -- >>> settingsSlowlorisSize defaultSettings
+    -- 50
+
     , settingsReadBufferSize :: Int
     -- ^ When the size of a read buffer is lower than this limit, the buffer is thrown awany (and is eventually freed). Then a new buffer is allocated. (All)
+    --
+    -- >>> settingsReadBufferSize defaultSettings
+    -- 16384
+
     , settingsReadBufferLowerLimit :: Int
     -- ^  The allocation size for a read buffer.  (All)
+    --
+    -- >>> settingsReadBufferLowerLimit defaultSettings
+    -- 2048
+
     , settingsKeyLogger :: String -> IO ()
     -- ^ Key logger (defaults to none)
     --
     -- Applications may wish to set this depending on the SSLKEYLOGFILE environment variable.
+    --
+    -- >>> settingsKeyLogger defaultSettings
+    -- \_ -> return ()
     }
 
 -- | Default settings.

--- a/Network/HTTP2/TLS/Server/Settings.hs
+++ b/Network/HTTP2/TLS/Server/Settings.hs
@@ -10,9 +10,9 @@ data Settings = Settings
     -- ^ If the size of receiving data is less than or equal,
     --   the timeout is not reset.
     --   (All)
-    , settingReadBufferSize :: Int
+    , settingsReadBufferSize :: Int
     -- ^ When the size of a read buffer is lower than this limit, the buffer is thrown awany (and is eventually freed). Then a new buffer is allocated. (All)
-    , settingReadBufferLowerLimit :: Int
+    , settingsReadBufferLowerLimit :: Int
     -- ^  The allocation size for a read buffer.  (All)
     , settingsKeyLogger :: String -> IO ()
     -- ^ Key logger (defaults to none)
@@ -27,7 +27,7 @@ defaultSettings =
         { settingsTimeout = 30
         , settingsSendBufferSize = 4096
         , settingsSlowlorisSize = 50
-        , settingReadBufferSize = 16384
-        , settingReadBufferLowerLimit = 2048
+        , settingsReadBufferSize = 16384
+        , settingsReadBufferLowerLimit = 2048
         , settingsKeyLogger = \_ -> return ()
         }

--- a/http2-tls.cabal
+++ b/http2-tls.cabal
@@ -24,9 +24,10 @@ library
         Network.HTTP2.TLS.Server
 
     other-modules:
+        Network.HTTP2.TLS.Client.Settings
         Network.HTTP2.TLS.Config
         Network.HTTP2.TLS.IO
-        Network.HTTP2.TLS.Settings
+        Network.HTTP2.TLS.Server.Settings
         Network.HTTP2.TLS.Supported
 
     default-language:   Haskell2010
@@ -35,6 +36,8 @@ library
     build-depends:
         base >=4.9 && <5,
         bytestring,
+        crypton-x509-store,
+        crypton-x509-validation,
         data-default-class,
         http2 >= 4.2.0,
         network,


### PR DESCRIPTION
@kazu-yamamoto this adds a `Settings` object for the client, in the same way that the server does. A few remarks:

* I've moved `../Settings.hs` to `../Server/Settings.hs`, to avoid confusion with `../Client/Settings.hs`
* I noticed that the server settings has a few fields prefixed with `settings` and a few with `setting`. I didn't change that, but stuck with `settings` for the fields that I added.
* I didn't change any defaults; most importantly, `settingsValidateCert` defaults to `False`, which is what you had in your code too. I am not sure if this is the right default (shouldn't clients validate server certificates by default..?) but since you had that as the default, I kept that default. The other default I wasn't sure about is `settingsAddrInfoFlags`, which I default to `[AI_ADDRCONFIG, AI_NUMERICHOST, AI_NUMERICSERV]`, which is what you had, but again, not sure if this is the right default for all clients.
* You are using `runTCPServer` from `network-run` but you are not using `runTCPClient`; I'm sure you have good reasons for doing that, but I was getting some threads being killed in my test suite; I did some comparison between what you're doing here and what `runTCPClient` does, and I think the crucial difference is that you're using `close` whereas `network-run` uses `gclose`; I've now copied the definition of `gclose` to `http2-tls` (it's not exported from `network-run`), and we're using that instead now.
* I have not added any configuration options to `runH2C`.
* I deleted the `Show` and `Eq` instance from `(Server.)Settings`, because it now contains a function. I'm not sure if that is a problem or not.

As always, if there is anything here that you think I should do differently, let me know! :)


