### PR TITLE
Improve dependencies

### DIFF
--- a/http2-tls.cabal
+++ b/http2-tls.cabal
@@ -42,7 +42,7 @@ library
         http2 >= 4.2.0,
         network,
         network-run >=0.2.6,
-        recv,
+        recv >=0.1.0,
         time-manager,
         tls >=1.7.0,
         unliftio

--- a/http2-tls.cabal
+++ b/http2-tls.cabal
@@ -36,13 +36,27 @@ library
     build-depends:
         base >=4.9 && <5,
         bytestring,
-        crypton-x509-store,
-        crypton-x509-validation,
         data-default-class,
         http2 >= 4.2.0,
         network,
         network-run >=0.2.6,
         recv >=0.1.0,
         time-manager,
-        tls >=1.7.0,
         unliftio
+
+    -- tls 1.7 starts using the crypton- forks of the x509-* packages
+    if flag(crypton)
+      build-depends:
+          tls >=1.7.0,
+          crypton-x509-store,
+          crypton-x509-validation
+    else
+      build-depends:
+          tls <1.7,
+          x509-store,
+          x509-validation
+
+Flag crypton
+    description: Use the crypton-x509-* package family instead of x509-*
+    default: True
+    manual: False


### PR DESCRIPTION
This PR makes two changes:

* It sets a lower bound on `recv` (we cannot build with `recv<0.1.0`); with thanks to @mrBliss
* It allows to build with `tls<1.7`, and consequently with the `x509-` packages prior to the `crypton-` forks. This makes it easier to use `http2-tls` in large builds where not all dependencies have migrated over to those forks (for example, there are packages that depend on `connection` vs `crypton-connection`). 