### PR TITLE
Use `defaultClientConfig`, improve forwards compat

### DIFF
--- a/Network/HTTP2/TLS/Client.hs
+++ b/Network/HTTP2/TLS/Client.hs
@@ -96,7 +96,7 @@ run' schm serverName send recv mysa peersa client =
         (\conf -> H2Client.run cliconf conf client)
   where
     cliconf =
-        ClientConfig
+        H2Client.defaultClientConfig
             { scheme = schm
             , authority = C8.pack serverName
             , cacheLimit = 20


### PR DESCRIPTION
This makes the lib compatible with `http2` after https://github.com/kazu-yamamoto/http2/commit/a60abcd1959a4bd655c228ebb89e959ef847a4e2 .