### PR TITLE
Reduce lower bound on `tls`

### DIFF
--- a/http2-tls.cabal
+++ b/http2-tls.cabal
@@ -44,12 +44,13 @@ library
         unliftio >= 0.2 && < 0.3,
         network-run >= 0.2.6 && < 0.3,
         network-control >= 0.0.2 && < 0.1,
-        recv >= 0.1.0 && < 0.2,
-        tls >= 1.9 && < 1.10
+        recv >= 0.1.0 && < 0.2
 
     if flag(crypton)
         build-depends:
-            tls >=1.9,
+            -- If we raise the lower bound on @tls@, then the @crypton@ flag
+            -- becomes useless and we should remove it.
+            tls >=1.7 && < 1.10,
             crypton-x509-store >= 1.6 && < 1.7,
             crypton-x509-validation >= 1.6 && < 1.7
 


### PR DESCRIPTION
In #3 we introduced the `crypton` flag, which allows `http2-tls` to be built with packages before or after the `crypton` package forks. However, [`cabal gen-bounds` later added a lower-bound of 1.9.0 on `tls`](https://github.com/kazu-yamamoto/http2-tls/commit/a876102f4a680fdfe1914ce4bc18faebc0ea68fb) (later [changed to 1.9](https://github.com/kazu-yamamoto/http2-tls/commit/a5ac8d9b423da9d28195b42c1b6c9e85613344f3)). However, the package builds just fine with older versions of `tls`, so I _think_ this lower bound is unnecessarily restrictive. 

If we really do need `tls >= 1.9`, then we should remove the `crypton` flag again, because as it stands, `http2-tls` is not actually buildable without this flag (inconsistent constraints in the `.cabal` file). I've added a note to this effect in the `.cabal` file itself as a reminder to ourselves.