### PR TITLE
Accept `ClientConfig`, use `authority` for SNI

### DIFF
--- a/Network/HTTP2/TLS/Client/Settings.hs
+++ b/Network/HTTP2/TLS/Client/Settings.hs
@@ -1,5 +1,6 @@
 module Network.HTTP2.TLS.Client.Settings where
 
+import Data.ByteString (ByteString)
 import Data.X509.CertificateStore (CertificateStore)
 import Network.Socket
 
@@ -22,6 +23,15 @@ data Settings = Settings
     -- True
     , settingsCAStore :: CertificateStore
     -- ^ Certificate store used for validation. The default is 'mempty'. (TLS and H2)
+    , settingsServerNameOverride :: Maybe ByteString
+    -- ^ Server name override
+    --
+    -- By default, the server name (for TLS SNI) is set based on the
+    -- 'Network.HTTP2.Client.authority', corresponding to the HTTP2
+    -- @:authority@ pseudo-header. In rare circumstances these two values should
+    -- be different (for example in the case of domain fronting);
+    -- 'settingsServerNameOverride' can be used to give SNI a different value
+    -- than @:authority@.
     , settingsAddrInfoFlags :: [AddrInfoFlag]
     -- ^ Flags that control the querying behaviour of @getAddrInfo@. (TLS and H2)
     --
@@ -56,6 +66,7 @@ defaultSettings =
         { settingsKeyLogger = \_ -> return ()
         , settingsValidateCert = True
         , settingsCAStore = mempty
+        , settingsServerNameOverride = Nothing
         , settingsAddrInfoFlags = []
         , settingsCacheLimit = cacheLimit defaultClientConfig
         , settingsConcurrentStreams = defaultMaxStreams

--- a/http2-tls.cabal
+++ b/http2-tls.cabal
@@ -44,7 +44,8 @@ library
         unliftio >= 0.2 && < 0.3,
         network-run >= 0.2.6 && < 0.3,
         network-control >= 0.0.2 && < 0.1,
-        recv >= 0.1.0 && < 0.2
+        recv >= 0.1.0 && < 0.2,
+        utf8-string >= 1.0 && < 1.1
 
     if flag(crypton)
         build-depends:


### PR DESCRIPTION
This enables client code to override specific parts of the `ClientConfig` if they so wish (for my specific use case, I have some clients who need to override the `authority` field for some router hardware). 

Note that `run` and `runH2C` still override the `scheme` field; the alternative would be to recommend to users to use `defaultClientConfig` from `http2` for `runH2C` and the `defaultClientConfig` from `http2-tls` for `run`. I don't mind either way.

@kazu-yamamoto By the way, I ran `fourmolu` on this branch, but the repo is missing the `fourmolu.yaml` file; I've used the one from the `http2` repo.