### PR TITLE
Introduce `settingsOpenServerSocket`

### DIFF
--- a/Network/HTTP2/TLS/Server/Settings.hs
+++ b/Network/HTTP2/TLS/Server/Settings.hs
@@ -5,6 +5,8 @@ import Network.HTTP2.Server (
     defaultServerConfig,
     numberOfWorkers,
  )
+import Network.Run.TCP.Timeout
+import Network.Socket
 import Network.TLS (SessionManager, noSessionManager)
 
 -- Server settings type.
@@ -62,6 +64,10 @@ data Settings = Settings
     -- 1048575
     , settingsSessionManager :: SessionManager
     -- ^ TLS session manager (H2 and TLS)
+    , settingsOpenServerSocket :: AddrInfo -> IO Socket
+    -- ^ Function to initialize the server socket
+    --
+    -- Defaults to 'openServerSocket'
     }
 
 -- | Default settings.
@@ -79,4 +85,5 @@ defaultSettings =
         , settingsStreamWindowSize = defaultMaxStreamData
         , settingsConnectionWindowSize = defaultMaxData
         , settingsSessionManager = noSessionManager
+        , settingsOpenServerSocket = openServerSocket
         }


### PR DESCRIPTION
This is a companion to https://github.com/kazu-yamamoto/network-run/pull/3 , and relies on that PR to have been merged before this will build.

This adds the additional argument of `runTCPServerWithSocket` as a new field of `Settings`, with `openServerSocket` as its default.