### PR TITLE
Compatibility with `tls < 2.0`

### DIFF
--- a/Network/HTTP2/TLS/Client.hs
+++ b/Network/HTTP2/TLS/Client.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE CPP #-}
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE RankNTypes #-}
 {-# LANGUAGE RecordWildCards #-}
@@ -239,7 +240,12 @@ getClientParams Settings{..} serverName port alpn =
         , clientShared = shared
         , clientHooks = hooks
         , clientDebug = debug
+#if MIN_VERSION_tls(2,0,0)
         , clientUseEarlyData = settingsUseEarlyData
+#else
+        , clientEarlyData = Nothing
+#endif
+
         }
   where
     shared =

--- a/Network/HTTP2/TLS/Client/Settings.hs
+++ b/Network/HTTP2/TLS/Client/Settings.hs
@@ -67,6 +67,8 @@ data Settings = Settings
     , settingsUseEarlyData :: Bool
     -- ^ Try to use 0-RTT (H2 and TLS)
     --
+    -- This is only supported for @tls >= 2.0@.
+    --
     -- >>> settingsUseEarlyData defaultSettings
     -- False
     }


### PR DESCRIPTION
@kazu-yamamoto I'm not entirely sure how you will feel about this PR. Since the comment of `settingsUseEarlyData` says to "_try_ to use 0-RTT" (my emphasis), it seems reasonable to me to simply _not_ do this if we are using an older version of `tls` (for completeness sake: `clientUseEarlyData` was introduced in https://github.com/haskell-tls/hs-tls/issues/466).  

If you think this PR is not what we should do, then we should at least change the lower-bound on `tls` because right now `http2-tls` will fail to build with `tls < 2.0` (rather than give a cabal error about versions). I think that would be a pity however, as it would make `http2-tls` incompatible with systems that for whatever reason are still using `x509*` rather than `crypton-x509*` (unfortunately, such systems are still out there).