### PR TITLE
using runTCPClient

### DIFF
--- a/Network/HTTP2/TLS/Client/Settings.hs
+++ b/Network/HTTP2/TLS/Client/Settings.hs
@@ -37,10 +37,7 @@ data Settings = Settings
     -- 'settingsServerNameOverride' can be used to give SNI a different value
     -- than @:authority@.
     , settingsAddrInfoFlags :: [AddrInfoFlag]
-    -- ^ Flags that control the querying behaviour of @getAddrInfo@. (TLS and H2)
-    --
-    -- >>> settingsAddrInfoFlags defaultSettings
-    -- []
+    -- ^ Obsoleted.
     , settingsCacheLimit :: Int
     -- ^ How many pushed responses are contained in the cache (H2 and H2c)
     --

--- a/Network/HTTP2/TLS/Internal.hs
+++ b/Network/HTTP2/TLS/Internal.hs
@@ -1,17 +1,5 @@
-{-# LANGUAGE CPP #-}
-
 module Network.HTTP2.TLS.Internal (
     module Network.HTTP2.TLS.IO,
-    gclose,
 ) where
 
-import Network.Socket
-
 import Network.HTTP2.TLS.IO
-
-gclose :: Socket -> IO ()
-#if MIN_VERSION_network(3,1,1)
-gclose sock = gracefulClose sock 5000
-#else
-gclose = close
-#endif

--- a/http2-tls.cabal
+++ b/http2-tls.cabal
@@ -46,7 +46,7 @@ library
         network >=3.1.4,
         time-manager >=0.0.1 && <0.1,
         unliftio >=0.2 && <0.3,
-        network-run >=0.2.6 && <0.3,
+        network-run >=0.2.8 && <0.3,
         network-control >=0.1 && <0.2,
         recv >=0.1.0 && <0.2,
         utf8-string >=1.0 && <1.1


### PR DESCRIPTION
This PR uses `runTCPClient` in `network-run`.

- `runTCPClient` of v0.2.8 specifies `AI_ADDRCONFIG` which is only necessary for client usage.
- It is very hard to pass `AddrInfoFlags` to `runTCPClient` and it seems unnecessary to me just because `AI_ADDRCONFIG` is good enough.
- So, `settingsAddrInfoFlags` is obsoleted.

@edsko Would you kindly review this PR?