### PR TITLE
Drop support for older `tls`

### DIFF
--- a/Network/HTTP2/TLS/Client.hs
+++ b/Network/HTTP2/TLS/Client.hs
@@ -1,4 +1,3 @@
-{-# LANGUAGE CPP #-}
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE RankNTypes #-}
 {-# LANGUAGE RecordWildCards #-}
@@ -48,10 +47,10 @@ import Data.Maybe (fromMaybe)
 import Data.X509.Validation (validateDefault)
 import Network.HTTP2.Client (Authority, Client, ClientConfig)
 import qualified Network.HTTP2.Client as H2Client
+import Network.Run.TCP
 import Network.Socket
 import Network.TLS hiding (HostName)
 import qualified UnliftIO.Exception as E
-import Network.Run.TCP
 
 import Network.HTTP2.TLS.Client.Settings
 import Network.HTTP2.TLS.Config
@@ -223,12 +222,7 @@ getClientParams Settings{..} serverName port alpn =
         , clientShared = shared
         , clientHooks = hooks
         , clientDebug = debug
-#if MIN_VERSION_tls(2,0,0)
         , clientUseEarlyData = settingsUseEarlyData
-#else
-        , clientEarlyData = Nothing
-#endif
-
         }
   where
     shared =

--- a/Network/HTTP2/TLS/IO.hs
+++ b/Network/HTTP2/TLS/IO.hs
@@ -1,4 +1,3 @@
-{-# LANGUAGE CPP #-}
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE RecordWildCards #-}
 
@@ -96,20 +95,14 @@ sendTLS ctx = sendData ctx . LBS.fromStrict
 sendManyTLS :: Context -> [ByteString] -> IO ()
 sendManyTLS ctx = sendData ctx . LBS.fromChunks
 
-{- FOURMOLU_DISABLE -}
 -- TLS version of recv (decrypting) without a cache.
 recvTLS :: Context -> IO ByteString
 recvTLS ctx = E.handle onEOF $ recvData ctx
   where
     onEOF e
-#if MIN_VERSION_tls(1,8,0)
         | Just (PostHandshake Error_EOF) <- E.fromException e = return ""
-#else
-        | Just Error_EOF <- E.fromException e = return ""
-#endif
         | Just ioe <- E.fromException e, isEOFError ioe = return ""
         | otherwise = E.throwIO e
-{- FOURMOLU_ENABLE -}
 
 ----------------------------------------------------------------
 

--- a/http2-tls.cabal
+++ b/http2-tls.cabal
@@ -15,9 +15,6 @@ source-repository head
     type:     git
     location: https://github.com/kazu-yamamoto/http2-tls
 
-flag crypton
-    description: Use the crypton-x509-* package family instead of x509-*
-
 flag devel
     description: Development commands
     default:     False
@@ -41,6 +38,8 @@ library
     build-depends:
         base >=4.9 && <5,
         bytestring >=0.10,
+        crypton-x509-store >=1.6 && <1.7,
+        crypton-x509-validation >=1.6 && <1.7,
         data-default-class >=0.1 && <0.2,
         http2 >=5.1 && <5.3,
         network >=3.1.4,
@@ -48,20 +47,9 @@ library
         network-run >=0.3 && <0.4,
         recv >=0.1.0 && <0.2,
         time-manager >=0.0.1 && <0.2,
+        tls >=2.1 && <2.2,
         unliftio >=0.2 && <0.3,
         utf8-string >=1.0 && <1.1
-
-    if flag(crypton)
-        build-depends:
-            tls >=2.1 && <2.2,
-            crypton-x509-store >=1.6 && <1.7,
-            crypton-x509-validation >=1.6 && <1.7
-
-    else
-        build-depends:
-            tls <1.7,
-            x509-store,
-            x509-validation
 
 executable h2-client
     main-is:            h2-client.hs


### PR DESCRIPTION
The `.cabal` file required `tls >= 2.1` when the `crypton` flag was enabled, but allowed for older versions of `tls` without it -- but if you then actually tried to build with older versions of `tls`, the build would fail. It has been relatively easy to support older versions of `tls` until now, but it's getting tricker now, so this PR just stops trying entirely.

@kazu-yamamoto , I was the one who introduced support for older `tls` in the first place, so I'm guessing you're fine with this PR. It _is_ a bit of a pity, as I _am_ still aware of at least one company who will now be unable to use recent `http2-tls` (and therefore also my `grapesy` library) because they are stuck with older versions of `tls` for now, but they are not a client of mine, and so maintaining support for older `tls` just seems too much hassle at this point. But if you see an easy way to keep it, that _would_ be better.