### PR TITLE
Add `settingsOpenClientSocket`

### DIFF
--- a/Network/HTTP2/TLS/Client/Settings.hs
+++ b/Network/HTTP2/TLS/Client/Settings.hs
@@ -8,6 +8,7 @@ import Network.HTTP2.Client (
     cacheLimit,
     defaultClientConfig,
  )
+import Network.Run.TCP (openClientSocket)
 import Network.TLS (
     Information,
     SessionData,
@@ -86,6 +87,10 @@ data Settings = Settings
     --
     -- >>> settingsUseEarlyData defaultSettings
     -- False
+    , settingsOpenClientSocket :: AddrInfo -> IO Socket
+    -- ^ Function to initialize the server socket (All)
+    --
+    -- Default: 'openClientSocket'
     , settingsOnServerFinished :: Information -> IO ()
     }
 
@@ -106,5 +111,6 @@ defaultSettings =
         , settingsWantSessionResume = Nothing
         , settingsWantSessionResumeList = []
         , settingsUseEarlyData = False
+        , settingsOpenClientSocket = openClientSocket
         , settingsOnServerFinished = \_ -> return ()
         }


### PR DESCRIPTION
This is the client equivalent of `settingsOpenServerSocket` (which was introduced in #10).

This is a companion PR to, and depends on, https://github.com/kazu-yamamoto/network-run/pull/8.

