### PR TITLE
Compatibility with `network-run`

### DIFF
--- a/Network/HTTP2/TLS/Server.hs
+++ b/Network/HTTP2/TLS/Server.hs
@@ -27,7 +27,6 @@ module Network.HTTP2.TLS.Server (
     settingsConnectionWindowSize,
     settingsStreamWindowSize,
     settingsSessionManager,
-    settingsOpenServerSocket,
     settingsEarlyDataSize,
 
     -- * IO backend

--- a/Network/HTTP2/TLS/Server/Settings.hs
+++ b/Network/HTTP2/TLS/Server/Settings.hs
@@ -5,8 +5,6 @@ import Network.HTTP2.Server (
     defaultServerConfig,
     numberOfWorkers,
  )
-import Network.Run.TCP.Timeout
-import Network.Socket
 import Network.TLS (SessionManager, noSessionManager)
 
 -- Server settings type.
@@ -68,10 +66,6 @@ data Settings = Settings
     -- ^ TLS session manager (H2 and TLS)
     --
     -- Default: 'noSessionManager'
-    , settingsOpenServerSocket :: AddrInfo -> IO Socket
-    -- ^ Function to initialize the server socket (All)
-    --
-    -- Default: 'openServerSocket'
     , settingsEarlyDataSize :: Int
     -- ^ The max size of early data (0-RTT) to be accepted. (H2 and TLS)
     -- 0 means that early data is not accepted.
@@ -95,6 +89,5 @@ defaultSettings =
         , settingsStreamWindowSize = defaultMaxStreamData
         , settingsConnectionWindowSize = defaultMaxData
         , settingsSessionManager = noSessionManager
-        , settingsOpenServerSocket = openServerSocket
         , settingsEarlyDataSize = 0
         }


### PR DESCRIPTION
This is a companion PR (note: here too into `main2`), to https://github.com/kazu-yamamoto/network-run/pull/9, following the discussion in https://github.com/kazu-yamamoto/http2-tls/pull/16. 

The only change this PR makes is that it drops `settingsOpenServerSocket`, which is no longer used (users should call `runWithSocket` instead of `run`).

@kazu-yamamoto I'm okay with the approach that you have implemented in `network-run:main2` and `http2-tls:main2`. I have a branch in `grapesy` against these two versions which works. The most important comment I have is that not only is user code now responsible for bracketing the socket creation, it is _also_ responsible for calling `listen` on that socket, even if they call `openServerSocket` (as well as `resolve`, see https://github.com/kazu-yamamoto/network-run/pull/9. Just as an example, the code in `grapesy` to create the server socket now looks like this:

```haskell
withServerSocket .. host port k = do
    addr <- Run.resolve Stream host (show port) [AI_PASSIVE]
    bracket (openServerSocket addr) close $ \sock -> do
      listen sock 1024
      ..
      k sock
  where
    openServerSocket :: AddrInfo -> IO Socket
    openServerSocket = Network.Run.TCP.openServerSocketWithOptions ..
```

This works, but is perhaps slightly less discoverable; in fact, if the user forgets that call to `listen`, the server will just fail to start with 

```
Network.Socket.accept: invalid argument (Invalid argument)
```

which is not exactly obvious. 

But having said that, I can work with this.