### PR TITLE
Expose client socket

### DIFF
--- a/Network/HTTP2/TLS/IO.hs
+++ b/Network/HTTP2/TLS/IO.hs
@@ -45,13 +45,15 @@ data IOBackend = IOBackend
     -- ^ Sending many.
     , recv :: IO ByteString
     -- ^ Receiving.
+    , requestSock :: Socket
+    -- ^ The socket for the request
     , mySockAddr :: SockAddr
     , peerSockAddr :: SockAddr
     }
 
 timeoutIOBackend :: T.Handle -> Settings -> IOBackend -> IOBackend
 timeoutIOBackend th Settings{..} IOBackend{..} =
-    IOBackend send' sendMany' recv' mySockAddr peerSockAddr
+    IOBackend send' sendMany' recv' requestSock mySockAddr peerSockAddr
   where
     send' bs = send bs >> T.tickle th
     sendMany' bss = sendMany bss >> T.tickle th
@@ -69,6 +71,7 @@ tlsIOBackend ctx sock = do
             { send = sendTLS ctx
             , sendMany = sendManyTLS ctx
             , recv = recvTLS ctx
+            , requestSock = sock
             , mySockAddr = mysa
             , peerSockAddr = peersa
             }
@@ -83,6 +86,7 @@ tcpIOBackend settings sock = do
             { send = void . NSB.send sock
             , sendMany = \_ -> return ()
             , recv = recv'
+            , requestSock = sock
             , mySockAddr = mysa
             , peerSockAddr = peersa
             }

--- a/Network/HTTP2/TLS/Server.hs
+++ b/Network/HTTP2/TLS/Server.hs
@@ -34,6 +34,7 @@ module Network.HTTP2.TLS.Server (
     send,
     sendMany,
     recv,
+    requestSock,
     mySockAddr,
     peerSockAddr,
 


### PR DESCRIPTION
We now have `openTCPServerSocketWithOptions` in `network-run` (https://github.com/kazu-yamamoto/network-run/pull/11), but we still have no way of settings socket opens on the sockets for each incoming request handled by the server (that is, for the sockets returned by `accept`). On _some_ systems, _some_ settings get inherited; for example, on Linux, `TCP_NODELAY` is inherited, although I can find no official documentation confirming this (tests confirm it, and so does https://notes.shichao.io/unp/ch7/#socket-states). However, for example on FreeBSD this is _not_ the case (https://man.freebsd.org/cgi/man.cgi?query=tcp). It is therefore important that we can set socket options also for these sockets; it suffices to expose the actual socket in the `IOBackend` (user code must then call `runTLSWithSocket` rather than `runWithSocket`, but that's okay).