### PR TITLE
Make rate limits configurable

### DIFF
--- a/Network/HTTP2/TLS/Client.hs
+++ b/Network/HTTP2/TLS/Client.hs
@@ -39,6 +39,12 @@ module Network.HTTP2.TLS.Client (
     settingsOpenClientSocket,
     settingsUseEarlyData,
     settingsOnServerFinished,
+
+    -- ** Rate limits
+    settingsPingRateLimit,
+    settingsEmptyFrameRateLimit,
+    settingsSettingsRateLimit,
+    settingsRstRateLimit,
 ) where
 
 import Data.ByteString (ByteString)
@@ -189,6 +195,10 @@ defaultClientConfig Settings{..} auth =
             (H2Client.settings $ H2Client.defaultClientConfig)
                 { H2Client.initialWindowSize = settingsStreamWindowSize
                 , H2Client.maxConcurrentStreams = Just settingsConcurrentStreams
+                , H2Client.pingRateLimit = settingsPingRateLimit
+                , H2Client.emptyFrameRateLimit = settingsEmptyFrameRateLimit
+                , H2Client.settingsRateLimit = settingsSettingsRateLimit
+                , H2Client.rstRateLimit = settingsRstRateLimit
                 }
         }
 

--- a/Network/HTTP2/TLS/Client/Settings.hs
+++ b/Network/HTTP2/TLS/Client/Settings.hs
@@ -92,6 +92,30 @@ data Settings = Settings
     --
     -- Default: 'openClientSocket'
     , settingsOnServerFinished :: Information -> IO ()
+
+    , settingsPingRateLimit :: Int
+    -- ^ Maximum number of pings allowed per second (CVE-2019-9512)
+    --
+    -- >>> settingsPingRateLimit defaultSettings
+    -- 10
+
+    , settingsEmptyFrameRateLimit :: Int
+    -- ^ Maximum number of empty data frames allowed per second (CVE-2019-9518)
+    --
+    -- >>> settingsEmptyFrameRateLimit defaultSettings
+    -- 4
+
+    , settingsSettingsRateLimit :: Int
+    -- ^ Maximum number of settings frames allowed per second (CVE-2019-9515)
+    --
+    -- >>> settingsSettingsRateLimit defaultSettings
+    -- 4
+
+    , settingsRstRateLimit :: Int
+    -- ^ Maximum number of reset frames allowed per second (CVE-2023-44487)
+    --
+    -- >>> settingsRstRateLimit
+    -- 4
     }
 
 -- | Default settings.
@@ -113,4 +137,8 @@ defaultSettings =
         , settingsUseEarlyData = False
         , settingsOpenClientSocket = openClientSocket
         , settingsOnServerFinished = \_ -> return ()
+        , settingsPingRateLimit = 10
+        , settingsEmptyFrameRateLimit = 4
+        , settingsSettingsRateLimit = 4
+        , settingsRstRateLimit = 4
         }

--- a/Network/HTTP2/TLS/Server.hs
+++ b/Network/HTTP2/TLS/Server.hs
@@ -29,6 +29,12 @@ module Network.HTTP2.TLS.Server (
     settingsSessionManager,
     settingsEarlyDataSize,
 
+    -- ** Rate limits
+    settingsPingRateLimit,
+    settingsEmptyFrameRateLimit,
+    settingsSettingsRateLimit,
+    settingsRstRateLimit,
+
     -- * IO backend
     IOBackend,
     send,
@@ -54,6 +60,10 @@ import Network.HTTP2.Server (
     initialWindowSize,
     maxConcurrentStreams,
     numberOfWorkers,
+    pingRateLimit,
+    emptyFrameRateLimit,
+    settingsRateLimit,
+    rstRateLimit,
     settings,
  )
 import qualified Network.HTTP2.Server as H2Server
@@ -174,6 +184,10 @@ run' settings0@Settings{..} server mgr IOBackend{..} =
                 (settings defaultServerConfig)
                     { initialWindowSize = settingsStreamWindowSize
                     , maxConcurrentStreams = Just settingsConcurrentStreams
+                    , pingRateLimit = settingsPingRateLimit
+                    , emptyFrameRateLimit = settingsEmptyFrameRateLimit
+                    , settingsRateLimit = settingsSettingsRateLimit
+                    , rstRateLimit = settingsRstRateLimit
                     }
             }
 
@@ -203,6 +217,10 @@ runIO' settings0@Settings{..} action mgr IOBackend{..} =
                 (settings defaultServerConfig)
                     { initialWindowSize = settingsStreamWindowSize
                     , maxConcurrentStreams = Just settingsConcurrentStreams
+                    , pingRateLimit = settingsPingRateLimit
+                    , emptyFrameRateLimit = settingsEmptyFrameRateLimit
+                    , settingsRateLimit = settingsSettingsRateLimit
+                    , rstRateLimit = settingsRstRateLimit
                     }
             }
 

--- a/Network/HTTP2/TLS/Server/Settings.hs
+++ b/Network/HTTP2/TLS/Server/Settings.hs
@@ -72,6 +72,30 @@ data Settings = Settings
     --
     -- >>> settingsEarlyDataSize defaultSettings
     -- 0
+
+    , settingsPingRateLimit :: Int
+    -- ^ Maximum number of pings allowed per second (CVE-2019-9512)
+    --
+    -- >>> settingsPingRateLimit defaultSettings
+    -- 10
+
+    , settingsEmptyFrameRateLimit :: Int
+    -- ^ Maximum number of empty data frames allowed per second (CVE-2019-9518)
+    --
+    -- >>> settingsEmptyFrameRateLimit defaultSettings
+    -- 4
+
+    , settingsSettingsRateLimit :: Int
+    -- ^ Maximum number of settings frames allowed per second (CVE-2019-9515)
+    --
+    -- >>> settingsSettingsRateLimit defaultSettings
+    -- 4
+
+    , settingsRstRateLimit :: Int
+    -- ^ Maximum number of reset frames allowed per second (CVE-2023-44487)
+    --
+    -- >>> settingsRstRateLimit
+    -- 4
     }
 
 -- | Default settings.
@@ -90,4 +114,8 @@ defaultSettings =
         , settingsConnectionWindowSize = defaultMaxData
         , settingsSessionManager = noSessionManager
         , settingsEarlyDataSize = 0
+        , settingsPingRateLimit = 10
+        , settingsEmptyFrameRateLimit = 4
+        , settingsSettingsRateLimit = 4
+        , settingsRstRateLimit = 4
         }


### PR DESCRIPTION
Adds rate limit settings to client/server settings used by TLS run functions. We use the same defaults as `http2`.