### PR TITLE
Remove `settingsNumberOfWorkers`

### DIFF
--- a/Network/HTTP2/TLS/Server.hs
+++ b/Network/HTTP2/TLS/Server.hs
@@ -22,7 +22,6 @@ module Network.HTTP2.TLS.Server (
     settingsReadBufferSize,
     settingsReadBufferLowerLimit,
     settingsKeyLogger,
-    settingsNumberOfWorkers,
     settingsConcurrentStreams,
     settingsConnectionWindowSize,
     settingsStreamWindowSize,
@@ -60,7 +59,6 @@ import Network.HTTP2.Server (
     emptyFrameRateLimit,
     initialWindowSize,
     maxConcurrentStreams,
-    numberOfWorkers,
     pingRateLimit,
     rstRateLimit,
     settings,
@@ -178,8 +176,7 @@ run' settings0@Settings{..} server mgr IOBackend{..} =
   where
     sconf =
         defaultServerConfig
-            { numberOfWorkers = settingsNumberOfWorkers
-            , connectionWindowSize = settingsConnectionWindowSize
+            { connectionWindowSize = settingsConnectionWindowSize
             , settings =
                 (settings defaultServerConfig)
                     { initialWindowSize = settingsStreamWindowSize
@@ -211,8 +208,7 @@ runIO' settings0@Settings{..} action mgr IOBackend{..} =
   where
     sconf =
         defaultServerConfig
-            { numberOfWorkers = settingsNumberOfWorkers
-            , connectionWindowSize = settingsConnectionWindowSize
+            { connectionWindowSize = settingsConnectionWindowSize
             , settings =
                 (settings defaultServerConfig)
                     { initialWindowSize = settingsStreamWindowSize

--- a/Network/HTTP2/TLS/Server/Settings.hs
+++ b/Network/HTTP2/TLS/Server/Settings.hs
@@ -2,8 +2,7 @@ module Network.HTTP2.TLS.Server.Settings where
 
 import Network.Control
 import Network.HTTP2.Server (
-    defaultServerConfig,
-    numberOfWorkers,
+    defaultServerConfig
  )
 import Network.TLS (SessionManager, noSessionManager)
 
@@ -42,11 +41,6 @@ data Settings = Settings
     -- Applications may wish to set this depending on the SSLKEYLOGFILE environment variable. The default is do nothing.
     --
     -- Default: do nothing
-    , settingsNumberOfWorkers :: Int
-    -- ^ The number of workers. (H2 and H2c)
-    --
-    -- >>> settingsNumberOfWorkers defaultSettings
-    -- 8
     , settingsConcurrentStreams :: Int
     -- ^ The maximum number of incoming streams on the net (H2 and H2c)
     --
@@ -108,7 +102,6 @@ defaultSettings =
         , settingsReadBufferSize = 16384
         , settingsReadBufferLowerLimit = 2048
         , settingsKeyLogger = \_ -> return ()
-        , settingsNumberOfWorkers = numberOfWorkers defaultServerConfig
         , settingsConcurrentStreams = defaultMaxStreams
         , settingsStreamWindowSize = defaultMaxStreamData
         , settingsConnectionWindowSize = defaultMaxData


### PR DESCRIPTION
With the new `http2` architecture, workers are no longer pooled. The `settingsNumberOfWorkers` server config field is therefore no longer necessary.

Corresponding `http2` PR: https://github.com/kazu-yamamoto/http2/pull/147 