### PR TITLE
Overriding authority with settingsServerNameOverride

### DIFF
--- a/Network/HTTP2/TLS/Client.hs
+++ b/Network/HTTP2/TLS/Client.hs
@@ -187,7 +187,7 @@ defaultClientConfig
 defaultClientConfig Settings{..} auth =
     H2Client.defaultClientConfig
         { H2Client.scheme = "https"
-        , H2Client.authority = auth
+        , H2Client.authority = fromMaybe auth settingsServerNameOverride
         , H2Client.cacheLimit = settingsCacheLimit
         , H2Client.connectionWindowSize = settingsConnectionWindowSize
         , H2Client.settings =


### PR DESCRIPTION
`settingsServerNameOverride` is used to override SNI of TLS.
But it is not used for `:authority` of HTTP/2.
This mismatch sometime results in communication failure.
An example is DNS over HTTP/2 served by Cloudflare (one.one.one.one).
I have a case where 1.1.1.1 must be specified as HostName but one.one.one.one should be specified to SNI and `:authority`.

@edsko What do you think?